### PR TITLE
Made _[meta-tag: status-review]_ render as code

### DIFF
--- a/burnination.md
+++ b/burnination.md
@@ -19,7 +19,7 @@ We have initially selected the following tags from that list:
 
 Taken from [this answer](http://meta.stackoverflow.com/a/307124/578411) by Shog9 and adapted for our purpose:
 
-1. When a [burninate-request](http://meta.stackoverflow.com/questions/tagged/burninate-request) is posted, it will be marked [meta-tag:status-review] until/unless it scores at least 20. 
+1. When a [burninate-request](http://meta.stackoverflow.com/questions/tagged/burninate-request) is posted, it will be marked `[meta-tag:status-review]` until/unless it scores at least 20. 
 If it never achieves this score, then it should not be acted on; don't interpret apathy as a sign of support.
 
 2. After reaching the threshold score, the request will be `[meta-tag:featured]` for one day, 


### PR DESCRIPTION
Surrounded _[meta-tag: status-review]_ with backticks