### PR TITLE
New question, SOCVR Code of Conduct

### DIFF
--- a/RoomMeetings.md
+++ b/RoomMeetings.md
@@ -9,6 +9,7 @@ Periodically SOCVR will have room-wide meetings where we discuss room policies a
 * Does the room need to be renamed so that it doesn't focus only on "Close" activity?
 * Are the activities of the room effective at meeting its goals? What can / should we do to make our votes more effective?
 * Are we okay with having a lot of members being privileged Smokey users? Should only RO be privileged in SOCVR and let members be privileged in Charcoal HQ if they really want to?
+* Should we have an SOCVR Code of Conduct that all regulars are expected to follow, not only in SOCVR but also on SO / MSO / chat / any and all SE places?
 
 ### Resolutions
 


### PR DESCRIPTION
This is related to our new pun-master RO answer [here](https://gist.github.com/mogsdad/c22cbb03cb7de02838cb#gistcomment-1721488):

> WE ARE ALWAYS AMBASSADORS FOR THE ROOM

This is totally badass and I think that it'd be great to have something more than "Be Nice" to offer our members. I'd like to discuss the idea of the redaction of a Code of Conduct during the meeting.  
The [General expectations for members](https://github.com/SO-Close-Vote-Reviewers/SOCVR-RoomInformation#general-expectations-for-members) is just a bunch of specific guidelines we've aggregated over the years. It does not cover the broader picture. The last rules are interesting but not developed enough.